### PR TITLE
Security vulnerability with dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
+
 gem 'jekyll', '~> 3.8', '>= 3.8.5'
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.1.1)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.14.0)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -249,4 +249,4 @@ DEPENDENCIES
   jemoji
 
 BUNDLED WITH
-   2.0.1
+   2.0.2

--- a/_posts/2008-10-29-dark-cast-rails-summit.md
+++ b/_posts/2008-10-29-dark-cast-rails-summit.md
@@ -15,11 +15,8 @@ Então é isso ai mesmo. O vídeo foi todo gravado dentro da Van… e pior no es
 
 Como eu estava filmando.. eu não fiz nenhum comentário sobre o assunto. Então dediquei-me o sábado inteiro para fazer um bom trabalho com a edição do vídeo. Espero que gostem!
 
-Mais uma noticia!! Eu comprei os dominios marcosz.com.br e marcosz.com. Em breve meu blog estará com nova cara e novo dominio.
-
+Mais uma noticia!! Eu comprei o dominio marcosz.com.br. Em breve meu blog estará com nova cara e novo dominio.
 
 <div class="embed-responsive embed-responsive-16by9">
   <iframe class="embed-responsive-item" src="https://player.vimeo.com/video/2094245" width="100%" height="100%" frameborder="0" title="DarkCast - Edição especial RailsSummit" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
 </div>
-
-

--- a/_posts/2019-05-24-rails-arel-calculate-distance-between-two-coordinates.markdown
+++ b/_posts/2019-05-24-rails-arel-calculate-distance-between-two-coordinates.markdown
@@ -3,7 +3,7 @@ layout: post
 title:  "Calculate distance between two coordinates using ActiveRecord Arel"
 date:   2019-05-24 08:17:15 -0300
 categories: ruby-on-rails
-tags: arel activerecord coordinates geolocation
+tags: arel activerecord coordinates geolocation mysql
 ---
 
 If you had to calculate the distance between two coordinates you probably found several different ways using the haversine formula:


### PR DESCRIPTION
A command injection vulnerability in Nokogiri v1.10.3 and earlier allows commands to be executed in a subprocess via Ruby's Kernel.open method. Processes are vulnerable only if the undocumented method Nokogiri::CSS::Tokenizer#load_file is being called with unsafe user input as the filename. This vulnerability appears in code generated by the Rexical gem versions v1.0.6 and earlier. Rexical is used by Nokogiri to generate lexical scanner code for parsing CSS queries. The underlying vulnerability was addressed in Rexical v1.0.7 and Nokogiri upgraded to this version of Rexical in Nokogiri v1.10.4.